### PR TITLE
refactor: init socket in index.tsx instead of App.tsx

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from "react";
-import { io } from "socket.io-client";
+import { Socket } from "socket.io-client";
 
-function App() {
-  const socket = io("http://localhost:5000");
+type Props = {
+  socket: Socket;
+};
 
+function App({ socket }: Props) {
   const [serverStatus, setServerStatus] = useState("connecting to server...");
 
   useEffect(() => {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-// import './index.css';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
+import { io } from "socket.io-client";
+
+const socket = io("http://localhost:5000");
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <App socket={socket}/>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );


### PR DESCRIPTION
Initialise `socket` in `src/index.tsx` instead of `src/App.tsx` so that `socket` is not re-initialised everytime component `App.tsx` is re-rendered.